### PR TITLE
feat: enhance Configuration Handling for Image Conversion Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Place your images in your desired directory (default: `./images`):
 
 ```
 your-project/
-├── images/            # default: ./images
+├── images/         # Directory for original images to convert(default: ./images)
 │   ├── image1.jpg
 │   ├── image2.png
 │   ├── image3.jpeg
@@ -119,7 +119,7 @@ your-project/
 │   │    ├── image4.jpg
 │   │    ├── image5.png
 │   │    └── image6.jpeg
-│   └── webp/            # converted images
+│   └── webp/         # Directory for converted images(default: ./images/webp)
 │       ├── image1.webp
 │       ├── image2.webp
 │       ├── image3.webp
@@ -137,6 +137,7 @@ When the conversion is performed, you can check the conversion information as sh
 
 <img width="758" alt="Image" src="https://github.com/user-attachments/assets/d426bb59-041a-474c-b36a-b1a95eef368c" />
 
+<br />
 <br />
 
 ## 🔧 Options
@@ -317,6 +318,38 @@ pnpm run webpc --crop.x 100 --crop.y 100 --crop.width 100 --crop.height 100
 npm run webpc --c.x 100 --c.y 100 --c.width 100 --c.height 100
 npm run webpc --crop.x 100 --crop.y 100 --crop.width 100 --crop.height 100
 ```
+
+<br />
+
+## 📝 Configuration
+
+You can also use a configuration file to customize the conversion process.
+
+create a `webpc.config.mjs` file in the root of your project.
+
+```
+your-project/
+├── images/
+├── src/
+├── package.json
+├── webpc.config.js
+└── ...
+```
+
+```ts
+// webpc.config.mjs
+export default {
+  path: "images",
+  destination: "images/webp2",
+  quality: 80,
+  lossless: false,
+  // ...
+};
+```
+
+**💡 Notes**
+
+> command-line interface (CLI) arguments take precedence over options defined in the configuration file.
 
 <br />
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "image-webp-converter",
   "type": "module",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Simple Image Webp Converter",
   "main": "./dist/index.mjs",
   "scripts": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,46 @@
+import fs from "fs";
+import path from "path";
+import { argv } from "./yargs.js";
+
+const DEFAULT_OPTIONS = {
+  path: "images",
+  destination: "images/webp",
+  quality: 75,
+  lossless: false,
+  size: null,
+  resize: null,
+  crop: null,
+};
+
+const configPath = [
+  path.resolve(process.cwd(), "webpc.config.js"),
+  path.resolve(process.cwd(), "webpc.config.mjs"),
+].find(fs.existsSync);
+
+const getConfigFileOptions = async () => {
+  if (fs.existsSync(configPath)) {
+    const config = await import(configPath);
+    return config.default;
+  }
+  return {};
+};
+
+export const getConfigOptions = async () => {
+  const config = await getConfigFileOptions();
+
+  const getSpecificOption = (path) => {
+    return argv[path] || config[path] || DEFAULT_OPTIONS[path];
+  };
+
+  const options = {
+    path: getSpecificOption("path"),
+    destination: getSpecificOption("destination"),
+    quality: getSpecificOption("quality"),
+    lossless: getSpecificOption("lossless"),
+    size: getSpecificOption("size"),
+    resize: getSpecificOption("resize"),
+    crop: getSpecificOption("crop"),
+  };
+
+  return options;
+};

--- a/src/config.js
+++ b/src/config.js
@@ -1,46 +1,15 @@
 import fs from "fs";
 import path from "path";
-import { argv } from "./yargs.js";
-
-const DEFAULT_OPTIONS = {
-  path: "images",
-  destination: "images/webp",
-  quality: 75,
-  lossless: false,
-  size: null,
-  resize: null,
-  crop: null,
-};
 
 const configPath = [
   path.resolve(process.cwd(), "webpc.config.js"),
   path.resolve(process.cwd(), "webpc.config.mjs"),
 ].find(fs.existsSync);
 
-const getConfigFileOptions = async () => {
+export const getConfigFileOptions = async () => {
   if (fs.existsSync(configPath)) {
     const config = await import(configPath);
     return config.default;
   }
   return {};
-};
-
-export const getConfigOptions = async () => {
-  const config = await getConfigFileOptions();
-
-  const getSpecificOption = (path) => {
-    return argv[path] || config[path] || DEFAULT_OPTIONS[path];
-  };
-
-  const options = {
-    path: getSpecificOption("path"),
-    destination: getSpecificOption("destination"),
-    quality: getSpecificOption("quality"),
-    lossless: getSpecificOption("lossless"),
-    size: getSpecificOption("size"),
-    resize: getSpecificOption("resize"),
-    crop: getSpecificOption("crop"),
-  };
-
-  return options;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,29 +2,30 @@
 
 import imagemin from "imagemin";
 import imageminWebp from "imagemin-webp";
-
-import { argv } from "./yargs.js";
 import { isValidFileFormat, printOptionsInfo, compareSize } from "./utils.js";
+import { getConfigOptions } from "./config.js";
 
 const ImageWebpConverter = async () => {
-  if (!isValidFileFormat()) return;
+  const options = await getConfigOptions();
 
-  printOptionsInfo();
+  if (!isValidFileFormat(options)) return;
 
-  await imagemin([`${argv.path}/**/*.{jpg,jpeg,png}`], {
-    destination: argv.destination,
+  printOptionsInfo(options);
+
+  await imagemin([`${options.path}/**/*.{jpg,jpeg,png}`], {
+    destination: options.destination,
     plugins: [
       imageminWebp({
-        quality: argv.quality,
-        lossless: argv.lossless,
-        size: argv.size,
-        resize: argv.resize,
-        crop: argv.crop,
+        quality: options.quality,
+        lossless: options.lossless,
+        size: options.size,
+        resize: options.resize,
+        crop: options.crop,
       }),
     ],
   });
 
-  compareSize();
+  compareSize(options);
 
   console.log("\n✅ Images have been successfully converted to Webp format!");
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,30 +2,31 @@
 
 import imagemin from "imagemin";
 import imageminWebp from "imagemin-webp";
+
+import { getArgv } from "./yargs.js";
 import { isValidFileFormat, printOptionsInfo, compareSize } from "./utils.js";
-import { getConfigOptions } from "./config.js";
 
 const ImageWebpConverter = async () => {
-  const options = await getConfigOptions();
+  const argv = await getArgv();
 
-  if (!isValidFileFormat(options)) return;
+  if (!isValidFileFormat(argv)) return;
 
-  printOptionsInfo(options);
+  printOptionsInfo(argv);
 
-  await imagemin([`${options.path}/**/*.{jpg,jpeg,png}`], {
-    destination: options.destination,
+  await imagemin([`${argv.path}/**/*.{jpg,jpeg,png}`], {
+    destination: argv.destination,
     plugins: [
       imageminWebp({
-        quality: options.quality,
-        lossless: options.lossless,
-        size: options.size,
-        resize: options.resize,
-        crop: options.crop,
+        quality: argv.quality,
+        lossless: argv.lossless,
+        size: argv.size,
+        resize: argv.resize,
+        crop: argv.crop,
       }),
     ],
   });
 
-  compareSize(options);
+  compareSize(argv);
 
   console.log("\n✅ Images have been successfully converted to Webp format!");
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,5 @@
 import fs from "fs";
 import path from "path";
-import { argv } from "./yargs.js";
 
 const IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "webp"];
 
@@ -35,8 +34,8 @@ const getCompareSize = (sourceFile, destinationFile) => {
   return { originalSize, newSize, savings };
 };
 
-export const isValidFileFormat = () => {
-  const files = getFiles(argv.path);
+export const isValidFileFormat = (options) => {
+  const files = getFiles(options.path);
 
   if (files.length === 0) {
     throw new Error("No files found in the directory");
@@ -56,12 +55,12 @@ export const isValidFileFormat = () => {
   return true;
 };
 
-export const compareSize = async () => {
-  const sourceFiles = getFiles(argv.path).filter(
+export const compareSize = (options) => {
+  const sourceFiles = getFiles(options.path).filter(
     (file) => path.extname(file).toLowerCase() !== ".webp"
   );
 
-  const destinationFiles = getFiles(argv.destination).filter(
+  const destinationFiles = getFiles(options.destination).filter(
     (file) => path.extname(file).toLowerCase() === ".webp"
   );
 
@@ -89,46 +88,46 @@ export const compareSize = async () => {
   }
 };
 
-export const printOptionsInfo = () => {
-  const options = [
+export const printOptionsInfo = (options) => {
+  const optionsInfo = [
     {
       label: "📁 Source/Destination",
-      value: `"${argv.path}" ➡️ "${argv.destination}"`,
+      value: `"${options.path}" ➡️ "${options.destination}"`,
       show: true,
     },
     {
       label: "🔍 Quality",
-      value: argv.quality,
+      value: options.quality,
       show: true,
     },
     {
       label: "🔒 Lossless",
-      value: argv.lossless,
+      value: options.lossless,
       show: true,
     },
     {
       label: "📐 Size",
-      value: argv.size,
-      show: !!argv.size,
+      value: options.size,
+      show: !!options.size,
     },
     {
       label: "📐 Resize",
       value:
-        argv.resize &&
-        `width: ${argv.resize.width}, height: ${argv.resize.height}`,
-      show: !!argv.resize,
+        options.resize &&
+        `width: ${options.resize.width}, height: ${options.resize.height}`,
+      show: !!options.resize,
     },
     {
       label: "📐 Crop",
       value:
-        argv.crop &&
-        `x: ${argv.crop.x}, y: ${argv.crop.y}, width: ${argv.crop.width}, height: ${argv.crop.height}`,
-      show: !!argv.crop,
+        options.crop &&
+        `x: ${options.crop.x}, y: ${options.crop.y}, width: ${options.crop.width}, height: ${options.crop.height}`,
+      show: !!options.crop,
     },
   ];
 
   console.log("\n📄 Options:");
-  options
+  optionsInfo
     .filter((opt) => opt.show)
     .forEach((opt, index) => {
       console.log(`${index + 1}. ${opt.label}: ${opt.value}`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,8 +34,8 @@ const getCompareSize = (sourceFile, destinationFile) => {
   return { originalSize, newSize, savings };
 };
 
-export const isValidFileFormat = (options) => {
-  const files = getFiles(options.path);
+export const isValidFileFormat = (argv) => {
+  const files = getFiles(argv.path);
 
   if (files.length === 0) {
     throw new Error("No files found in the directory");
@@ -55,12 +55,12 @@ export const isValidFileFormat = (options) => {
   return true;
 };
 
-export const compareSize = (options) => {
-  const sourceFiles = getFiles(options.path).filter(
+export const compareSize = async (argv) => {
+  const sourceFiles = getFiles(argv.path).filter(
     (file) => path.extname(file).toLowerCase() !== ".webp"
   );
 
-  const destinationFiles = getFiles(options.destination).filter(
+  const destinationFiles = getFiles(argv.destination).filter(
     (file) => path.extname(file).toLowerCase() === ".webp"
   );
 
@@ -88,46 +88,46 @@ export const compareSize = (options) => {
   }
 };
 
-export const printOptionsInfo = (options) => {
-  const optionsInfo = [
+export const printOptionsInfo = (argv) => {
+  const options = [
     {
       label: "📁 Source/Destination",
-      value: `"${options.path}" ➡️ "${options.destination}"`,
+      value: `"${argv.path}" ➡️ "${argv.destination}"`,
       show: true,
     },
     {
       label: "🔍 Quality",
-      value: options.quality,
+      value: argv.quality,
       show: true,
     },
     {
       label: "🔒 Lossless",
-      value: options.lossless,
+      value: argv.lossless,
       show: true,
     },
     {
       label: "📐 Size",
-      value: options.size,
-      show: !!options.size,
+      value: argv.size,
+      show: !!argv.size,
     },
     {
       label: "📐 Resize",
       value:
-        options.resize &&
-        `width: ${options.resize.width}, height: ${options.resize.height}`,
-      show: !!options.resize,
+        argv.resize &&
+        `width: ${argv.resize.width}, height: ${argv.resize.height}`,
+      show: !!argv.resize,
     },
     {
       label: "📐 Crop",
       value:
-        options.crop &&
-        `x: ${options.crop.x}, y: ${options.crop.y}, width: ${options.crop.width}, height: ${options.crop.height}`,
-      show: !!options.crop,
+        argv.crop &&
+        `x: ${argv.crop.x}, y: ${argv.crop.y}, width: ${argv.crop.width}, height: ${argv.crop.height}`,
+      show: !!argv.crop,
     },
   ];
 
   console.log("\n📄 Options:");
-  optionsInfo
+  options
     .filter((opt) => opt.show)
     .forEach((opt, index) => {
       console.log(`${index + 1}. ${opt.label}: ${opt.value}`);

--- a/src/yargs.js
+++ b/src/yargs.js
@@ -1,5 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
+import { getConfigFileOptions } from "./config.js";
 
 const DESCRIPTIONS = {
   path: "Images directory path",
@@ -11,58 +12,85 @@ const DESCRIPTIONS = {
   crop: "Crop the image (format: { width: number, height: number, x: number, y: number })",
 };
 
-export const argv = yargs(hideBin(process.argv))
-  .option("path", {
-    alias: "p",
-    description: DESCRIPTIONS.path,
-    type: "string",
-  })
-  .option("destination", {
-    alias: "d",
-    description: DESCRIPTIONS.destination,
-    type: "string",
-  })
-  .option("quality", {
-    alias: "q",
-    description: DESCRIPTIONS.quality,
-    type: "number",
-    coerce: (value) => {
-      if (value < 1 || value > 100) {
-        throw new Error("Quality must be between 1 and 100");
-      }
-      return value;
-    },
-  })
-  .option("lossless", {
-    alias: "l",
-    description: DESCRIPTIONS.lossless,
-    type: "boolean",
-  })
-  .option("size", {
-    alias: "s",
-    description: DESCRIPTIONS.size,
-    type: "number",
-  })
-  .option("resize", {
-    alias: "r",
-    description: DESCRIPTIONS.resize,
-    type: "object",
-    coerce: (value) => {
-      if (!value.width || !value.height) {
-        throw new Error("Resize requires both width and height");
-      }
-      return value;
-    },
-  })
-  .option("crop", {
-    alias: "c",
-    description: DESCRIPTIONS.crop,
-    type: "object",
-    coerce: (value) => {
-      if (!value.width || !value.height || !value.x || !value.y) {
-        throw new Error("Crop requires width, height, x, and y coordinates");
-      }
-      return value;
-    },
-  })
-  .help().argv;
+const DEFAULT_OPTIONS = {
+  path: "images",
+  destination: "images/webp",
+  quality: 75,
+  lossless: false,
+  size: null,
+  resize: null,
+  crop: null,
+};
+
+export const getArgv = async () => {
+  const configFileOptions = await getConfigFileOptions();
+
+  return yargs(hideBin(process.argv))
+    .option("path", {
+      alias: "p",
+      description: DESCRIPTIONS.path,
+      default: configFileOptions.path || DEFAULT_OPTIONS.path,
+      type: "string",
+    })
+    .option("destination", {
+      alias: "d",
+      description: DESCRIPTIONS.destination,
+      default: configFileOptions.destination || DEFAULT_OPTIONS.destination,
+      type: "string",
+    })
+    .option("quality", {
+      alias: "q",
+      description: DESCRIPTIONS.quality,
+      default: configFileOptions.quality || DEFAULT_OPTIONS.quality,
+      type: "number",
+      coerce: (value) => {
+        if (value < 1 || value > 100) {
+          throw new Error("Quality must be between 1 and 100");
+        }
+        return value;
+      },
+    })
+    .option("lossless", {
+      alias: "l",
+      description: DESCRIPTIONS.lossless,
+      default: configFileOptions.lossless || DEFAULT_OPTIONS.lossless,
+      type: "boolean",
+    })
+    .option("size", {
+      alias: "s",
+      description: DESCRIPTIONS.size,
+      default: configFileOptions.size || DEFAULT_OPTIONS.size,
+      type: "number",
+      coerce: (value) => {
+        if (value == null) return null;
+        return value;
+      },
+    })
+    .option("resize", {
+      alias: "r",
+      description: DESCRIPTIONS.resize,
+      default: configFileOptions.resize || DEFAULT_OPTIONS.resize,
+      type: "object",
+      coerce: (value) => {
+        if (value == null) return null;
+        if (!value.width || !value.height) {
+          throw new Error("Resize requires both width and height");
+        }
+        return value;
+      },
+    })
+    .option("crop", {
+      alias: "c",
+      description: DESCRIPTIONS.crop,
+      default: configFileOptions.crop || DEFAULT_OPTIONS.crop,
+      type: "object",
+      coerce: (value) => {
+        if (value == null) return null;
+        if (!value.width || !value.height || !value.x || !value.y) {
+          throw new Error("Crop requires width, height, x, and y coordinates");
+        }
+        return value;
+      },
+    })
+    .help().argv;
+};

--- a/src/yargs.js
+++ b/src/yargs.js
@@ -15,19 +15,16 @@ export const argv = yargs(hideBin(process.argv))
   .option("path", {
     alias: "p",
     description: DESCRIPTIONS.path,
-    default: "images",
     type: "string",
   })
   .option("destination", {
     alias: "d",
     description: DESCRIPTIONS.destination,
-    default: "images/webp",
     type: "string",
   })
   .option("quality", {
     alias: "q",
     description: DESCRIPTIONS.quality,
-    default: 75,
     type: "number",
     coerce: (value) => {
       if (value < 1 || value > 100) {
@@ -39,7 +36,6 @@ export const argv = yargs(hideBin(process.argv))
   .option("lossless", {
     alias: "l",
     description: DESCRIPTIONS.lossless,
-    default: false,
     type: "boolean",
   })
   .option("size", {


### PR DESCRIPTION
## Overview

This pull request introduces functionality to handle image conversion options based on a configuration file (`webpc.config.mjs`) if it exists in the current working directory.

## Benefits
This enhancement allows users to define their image conversion settings in a configuration file, making the tool more user-friendly and adaptable to different workflows.

## Example

```
your-project/
├── images/     
├── src/
├── package.json
├── webpc.config.js
└── ...
```
```ts
// webpc.config.mjs
export default {
  path: "images",
  destination: "images/webp2",
  quality: 75,
  lossless: false,
  // ...
};
```

### 💡 Note
> command-line interface (CLI) arguments take precedence over options defined in the configuration file.